### PR TITLE
[Auth Service] User \u0026 JWT Implementation (#14)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -12,13 +12,16 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"prompt-management/internal/config"
+	"prompt-management/internal/handler"
 	"prompt-management/internal/repository/postgres"
+	"prompt-management/internal/service"
 )
 
 type application struct {
-	config *config.Config
-	logger *slog.Logger
-	db     *pgxpool.Pool
+	config  *config.Config
+	logger  *slog.Logger
+	db      *pgxpool.Pool
+	auth    *handler.AuthHandler
 }
 
 func main() {
@@ -36,10 +39,16 @@ func main() {
 	}
 	defer dbPool.Close()
 
+	// 4. Initialize Handlers/Services
+	userRepo := postgres.NewUserRepository(dbPool)
+	authService := service.NewAuthService(cfg, userRepo)
+	authHandler := handler.NewAuthHandler(authService)
+
 	app := &application{
 		config: cfg,
 		logger: logger,
 		db:     dbPool,
+		auth:   authHandler,
 	}
 
 	// 4. Setup Server

--- a/cmd/api/router.go
+++ b/cmd/api/router.go
@@ -7,9 +7,13 @@ import (
 func (app *application) routes() http.Handler {
 	mux := http.NewServeMux()
 
-	// 1. Register handlers
+	// 1. Health check (GET/POST)
 	mux.HandleFunc("/health", app.healthCheckHandler)
 
-	// 2. Wrap with middleware
+	// 2. Authentication (POST-only per service handler)
+	mux.HandleFunc("/auth/register", app.auth.Register)
+	mux.HandleFunc("/auth/login", app.auth.Login)
+
+	// wrapping with middleware
 	return app.recoverPanic(app.logRequest(mux))
 }

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,17 @@ module prompt-management
 
 go 1.24.5
 
-require github.com/jackc/pgx/v5 v5.7.1
+require (
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/jackc/pgx/v5 v5.7.1
+	golang.org/x/crypto v0.31.0
+)
 
 require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
-	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -1,0 +1,25 @@
+package domain
+
+import (
+	"context"
+	"time"
+)
+
+// User represents the user entity in the system.
+type User struct {
+	ID           string     `json:"id"`
+	Email        string     `json:"email"`
+	Username     string     `json:"username"`
+	FullName     string     `json:"full_name"`
+	PasswordHash string     `json:"-"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+	DeletedAt    *time.Time `json:"-"`
+}
+
+// UserStore defines the interface for user persistence.
+type UserStore interface {
+	Insert(ctx context.Context, user *User) error
+	GetByEmail(ctx context.Context, email string) (*User, error)
+	GetByUsername(ctx context.Context, username string) (*User, error)
+}

--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -1,0 +1,83 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"prompt-management/internal/domain"
+	"prompt-management/internal/service"
+	"prompt-management/pkg/response"
+	"prompt-management/pkg/validator"
+)
+
+type AuthHandler struct {
+	service *service.AuthService
+}
+
+func NewAuthHandler(s *service.AuthService) *AuthHandler {
+	return &AuthHandler{service: s}
+}
+
+type registerRequest struct {
+	Email    string `json:"email"`
+	Username string `json:"username"`
+	FullName string `json:"full_name"`
+	Password string `json:"password"`
+}
+
+func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.Error(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var input registerRequest
+	err := validator.DecodeAndValidate(r, &input)
+	if err != nil {
+		response.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	user, err := h.service.Register(r.Context(), input.Email, input.Username, input.FullName, input.Password)
+	if err != nil {
+		if errors.Is(err, domain.ErrConflict) {
+			response.Error(w, http.StatusConflict, "user with this email or username already exists")
+			return
+		}
+		response.Error(w, http.StatusInternalServerError, "failed to register user")
+		return
+	}
+
+	response.JSON(w, http.StatusCreated, user)
+}
+
+type loginRequest struct {
+	Identifier string `json:"identifier"`
+	Password   string `json:"password"`
+}
+
+func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.Error(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var input loginRequest
+	err := validator.DecodeAndValidate(r, &input)
+	if err != nil {
+		response.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	token, err := h.service.Login(r.Context(), input.Identifier, input.Password)
+	if err != nil {
+		if errors.Is(err, domain.ErrUnauthorized) {
+			response.Error(w, http.StatusUnauthorized, "invalid credentials")
+			return
+		}
+		response.Error(w, http.StatusInternalServerError, "login failed")
+		return
+	}
+
+	response.JSON(w, http.StatusOK, map[string]string{"token": token})
+}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"prompt-management/internal/config"
+	"prompt-management/pkg/auth"
+	"prompt-management/pkg/response"
+)
+
+type contextKey string
+
+const UserIDContextKey contextKey = "user_id"
+
+// Authenticate is a middleware that validates the JWT in the Authorization header.
+func Authenticate(cfg *config.Config, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			response.Error(w, http.StatusUnauthorized, "missing authorization header")
+			return
+		}
+
+		parts := strings.Split(authHeader, " ")
+		if len(parts) != 2 || parts[0] != "Bearer" {
+			response.Error(w, http.StatusUnauthorized, "invalid authorization format")
+			return
+		}
+
+		token := parts[1]
+		claims, err := auth.ValidateToken(token, cfg.JWTSecret)
+		if err != nil {
+			response.Error(w, http.StatusUnauthorized, "invalid or expired token")
+			return
+		}
+
+		// Inject user ID into context
+		ctx := context.WithValue(r.Context(), UserIDContextKey, claims.UserID)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/internal/repository/postgres/user_repository.go
+++ b/internal/repository/postgres/user_repository.go
@@ -1,0 +1,81 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"prompt-management/internal/domain"
+)
+
+type userRepo struct {
+	db *pgxpool.Pool
+}
+
+// NewUserRepository creates a new PostgreSQL user repository.
+func NewUserRepository(db *pgxpool.Pool) domain.UserStore {
+	return &userRepo{db: db}
+}
+
+func (r *userRepo) Insert(ctx context.Context, user *domain.User) error {
+	query := `
+		INSERT INTO users (email, username, full_name, password_hash)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, created_at, updated_at`
+
+	args := []interface{}{
+		user.Email,
+		user.Username,
+		user.FullName,
+		user.PasswordHash,
+	}
+
+	err := r.db.QueryRow(ctx, query, args...).Scan(&user.ID, &user.CreatedAt, &user.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("could not insert user: %w", err)
+	}
+
+	return nil
+}
+
+func (r *userRepo) GetByEmail(ctx context.Context, email string) (*domain.User, error) {
+	query := `
+		SELECT id, email, username, full_name, password_hash, created_at, updated_at
+		FROM users
+		WHERE email = $1 AND deleted_at IS NULL`
+
+	return r.findOne(ctx, query, email)
+}
+
+func (r *userRepo) GetByUsername(ctx context.Context, username string) (*domain.User, error) {
+	query := `
+		SELECT id, email, username, full_name, password_hash, created_at, updated_at
+		FROM users
+		WHERE username = $1 AND deleted_at IS NULL`
+
+	return r.findOne(ctx, query, username)
+}
+
+func (r *userRepo) findOne(ctx context.Context, query string, arg interface{}) (*domain.User, error) {
+	var user domain.User
+	err := r.db.QueryRow(ctx, query, arg).Scan(
+		&user.ID,
+		&user.Email,
+		&user.Username,
+		&user.FullName,
+		&user.PasswordHash,
+		&user.CreatedAt,
+		&user.UpdatedAt,
+	)
+
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("could not find user: %w", err)
+	}
+
+	return &user, nil
+}

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -1,0 +1,97 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"prompt-management/internal/config"
+	"prompt-management/internal/domain"
+	"prompt-management/pkg/auth"
+)
+
+type AuthService struct {
+	config *config.Config
+	store  domain.UserStore
+}
+
+func NewAuthService(cfg *config.Config, store domain.UserStore) *AuthService {
+	return &AuthService{
+		config: cfg,
+		store:  store,
+	}
+}
+
+// Register creates a new user account.
+func (s *AuthService) Register(ctx context.Context, email, username, fullName, password string) (*domain.User, error) {
+	// 1. Validation basics
+	email = strings.ToLower(strings.TrimSpace(email))
+	username = strings.ToLower(strings.TrimSpace(username))
+
+	// 2. Check if user already exists (Email or Username)
+	_, err := s.store.GetByEmail(ctx, email)
+	if err == nil {
+		return nil, domain.ErrConflict // Email already in use
+	}
+	
+	_, err = s.store.GetByUsername(ctx, username)
+	if err == nil {
+		return nil, domain.ErrConflict // Username already in use
+	}
+
+	// 3. Hash Password
+	hashed, err := auth.HashPassword(password)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash password: %w", err)
+	}
+
+	// 4. Create User
+	user := &domain.User{
+		Email:        email,
+		Username:     username,
+		FullName:     fullName,
+		PasswordHash: hashed,
+	}
+
+	err = s.store.Insert(ctx, user)
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}
+
+// Login verifies credentials and returns a JWT.
+func (s *AuthService) Login(ctx context.Context, identifier, password string) (string, error) {
+	var user *domain.User
+	var err error
+
+	// 1. Try to find user by email or username
+	if strings.Contains(identifier, "@") {
+		user, err = s.store.GetByEmail(ctx, strings.ToLower(identifier))
+	} else {
+		user, err = s.store.GetByUsername(ctx, strings.ToLower(identifier))
+	}
+
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return "", domain.ErrUnauthorized
+		}
+		return "", err
+	}
+
+	// 2. Verify Password
+	if !auth.CheckPasswordHash(password, user.PasswordHash) {
+		return "", domain.ErrUnauthorized
+	}
+
+	// 3. Generate JWT
+	token, err := auth.GenerateToken(user.ID, s.config.JWTSecret, 24*time.Hour)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate token: %w", err)
+	}
+
+	return token, nil
+}

--- a/internal/service/auth_service_test.go
+++ b/internal/service/auth_service_test.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"prompt-management/internal/config"
+	"prompt-management/internal/domain"
+)
+
+// MockStore is a simple in-memory implementation of UserStore for testing.
+type MockStore struct {
+	users map[string]*domain.User
+}
+
+func (m *MockStore) Insert(ctx context.Context, user *domain.User) error {
+	user.ID = "generated-uuid"
+	m.users[user.Email] = user
+	return nil
+}
+
+func (m *MockStore) GetByEmail(ctx context.Context, email string) (*domain.User, error) {
+	u, ok := m.users[email]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	return u, nil
+}
+
+func (m *MockStore) GetByUsername(ctx context.Context, username string) (*domain.User, error) {
+	for _, u := range m.users {
+		if u.Username == username {
+			return u, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+
+func TestAuthServiceRegisterAndLogin(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "secret"}
+	store := &MockStore{users: make(map[string]*domain.User)}
+	svc := NewAuthService(cfg, store)
+	ctx := context.Background()
+
+	email := "test@example.com"
+	_, username, fullName, password := email, "testuser", "Test User", "password123"
+
+	t.Run("Successful Registration", func(t *testing.T) {
+		_, err := svc.Register(ctx, email, username, fullName, password)
+		if err != nil {
+			t.Fatalf("failed to register: %v", err)
+		}
+	})
+
+	t.Run("Duplicate Registration Email", func(t *testing.T) {
+		_, err := svc.Register(ctx, email, "otheruser", fullName, password)
+		if err == nil {
+			t.Fatal("expected conflict error for existing email, got nil")
+		}
+	})
+
+	t.Run("Successful Login - Email", func(t *testing.T) {
+		token, err := svc.Login(ctx, email, password)
+		if err != nil {
+			t.Fatalf("failed to login: %v", err)
+		}
+		if token == "" {
+			t.Fatal("expected token, got empty string")
+		}
+	})
+
+	t.Run("Successful Login - Username", func(t *testing.T) {
+		token, err := svc.Login(ctx, username, password)
+		if err != nil {
+			t.Fatalf("failed to login with username: %v", err)
+		}
+		if token == "" {
+			t.Error("expected token, got empty string")
+		}
+	})
+
+	t.Run("Invalid Password", func(t *testing.T) {
+		_, err := svc.Login(ctx, email, "wrongpassword")
+		if err == nil {
+			t.Fatal("expected unauthorized error, got nil")
+		}
+	})
+}

--- a/migrations/000001_create_users_table.up.sql
+++ b/migrations/000001_create_users_table.up.sql
@@ -1,0 +1,14 @@
+-- 000001_create_users_table.up.sql
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email TEXT UNIQUE NOT NULL,
+    username TEXT UNIQUE NOT NULL,
+    full_name TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_email ON users (email) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_users_username ON users (username) WHERE deleted_at IS NULL;

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPasswordHashing(t *testing.T) {
+	password := "super-secret-password"
+	
+	hash, err := HashPassword(password)
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+
+	if hash == password {
+		t.Errorf("expected hash to be different from original password")
+	}
+
+	if !CheckPasswordHash(password, hash) {
+		t.Errorf("expected password to match hash")
+	}
+
+	if CheckPasswordHash("wrong-password", hash) {
+		t.Errorf("expected wrong password to not match hash")
+	}
+}
+
+func TestJWTToken(t *testing.T) {
+	secret := "test-secret"
+	userID := "user-123"
+	expiration := time.Hour
+
+	token, err := GenerateToken(userID, secret, expiration)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	claims, err := ValidateToken(token, secret)
+	if err != nil {
+		t.Fatalf("failed to validate token: %v", err)
+	}
+
+	if claims.UserID != userID {
+		t.Errorf("expected UserID %s, got %s", userID, claims.UserID)
+	}
+
+	_, err = ValidateToken(token, "wrong-secret")
+	if err == nil {
+		t.Error("expected error for wrong secret, got nil")
+	}
+}

--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type Claims struct {
+	UserID string `json:"user_id"`
+	jwt.RegisteredClaims
+}
+
+// GenerateToken creates a new JWT for a specific user.
+func GenerateToken(userID string, secret string, expiresAt time.Duration) (string, error) {
+	claims := Claims{
+		UserID: userID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiresAt)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			NotBefore: jwt.NewNumericDate(time.Now()),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(secret))
+}
+
+// ValidateToken parses and validates a JWT.
+func ValidateToken(tokenString string, secret string) (*Claims, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return []byte(secret), nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if claims, ok := token.Claims.(*Claims); ok && token.Valid {
+		return claims, nil
+	}
+
+	return nil, fmt.Errorf("invalid token")
+}

--- a/pkg/auth/password.go
+++ b/pkg/auth/password.go
@@ -1,0 +1,17 @@
+package auth
+
+import (
+	"golang.org/x/crypto/bcrypt"
+)
+
+// HashPassword generates a bcrypt hash of the password.
+func HashPassword(password string) (string, error) {
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 12)
+	return string(bytes), err
+}
+
+// CheckPasswordHash compares a bcrypt hashed password with its possible plaintext equivalent.
+func CheckPasswordHash(password, hash string) bool {
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+	return err == nil
+}


### PR DESCRIPTION
This PR implements the Authentication Service (Phase 2). It provides user registration with profile fields and stateless JWT-based authentication.

### Key Changes
- **Migrations**: Created `000001_create_users_table.up.sql` with `email`, `username`, and `full_name`.
- **Domain**: Defined `User` entity and `UserRepository` interface.
- **Service**: Implemented `AuthService` with:
    - User registration (Bcrypt password hashing).
    - Login with dual identifier support (Email or Username).
    - JWT generation (HS256).
- **Handlers**: Added `POST /auth/register` and `POST /auth/login`.
- **Middleware**: Implemented `Authenticate` middleware for protecting downstream routes.
- **Testing**: Added unit tests for hashing, JWT lifecycle, and auth service logic.

References #14