### PR TITLE
[Management Service] Implement Prompt Group CRUD

### DIFF
--- a/.agent/rules/interlock.md
+++ b/.agent/rules/interlock.md
@@ -26,6 +26,7 @@ All feature development or bug fixes MUST follow this strict 9-step sequence:
 - **NEVER create a Pull Request without comprehensive testing/verification.**
 - **NEVER skip the PR process for any sub-issue or task.**
 - **NEVER commit logic without accompanying test cases.**
+- **NEVER close a GitHub ticket/issue before the corresponding Pull Request has been merged into the default branch.**
 
 ## 3. Architectural Constraints (CRITICAL)
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -43,12 +43,19 @@ func main() {
 	userRepo := postgres.NewUserRepository(dbPool)
 	authService := service.NewAuthService(cfg, userRepo)
 	authHandler := handler.NewAuthHandler(authService)
+
+	mgmtRepo := postgres.NewManagementRepository(dbPool)
+	mgmtService := service.NewManagementService(mgmtRepo)
+	mgmtHandler := handler.NewManagementHandler(mgmtService)
+
 	healthHandler := handler.NewHealthHandler(dbPool)
 
 	// 5. Setup Router
 	mux := handler.NewRouter(handler.RouterConfig{
-		Health: healthHandler,
-		Auth:   authHandler,
+		Config:     cfg,
+		Health:     healthHandler,
+		Auth:       authHandler,
+		Management: mgmtHandler,
 	})
 
 	// 6. Apply Global Middleware

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
       POSTGRES_DB: ${DB_NAME:-prompt_management}
     ports:
-      - "${DB_PORT:-5432}:5432"
+      - "${DB_PORT:-5433}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ type Config struct {
 
 func Load() *Config {
 	return &Config{
-		DatabaseURL:       getEnv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/prompt_management?sslmode=disable"),
+		DatabaseURL:       getEnv("DATABASE_URL", "postgres://postgres:postgres@127.0.0.1:5433/prompt_management?sslmode=disable"),
 		JWTSecret:         getEnv("JWT_SECRET", "super-secret-jwt-key"),
 		Port:               getEnv("PORT", "8080"),
 		DBMaxConns:        getEnv("DB_MAX_CONNS", "25"),

--- a/internal/domain/prompt.go
+++ b/internal/domain/prompt.go
@@ -1,0 +1,38 @@
+package domain
+
+import (
+	"context"
+	"time"
+)
+
+// PromptManagement represents a prompt metadata group.
+type PromptManagement struct {
+	ID           string     `json:"id"`
+	Client       string     `json:"client"`
+	UseCase      string     `json:"use_case"`
+	DocumentType string     `json:"document_type"`
+	Category     string     `json:"category"`
+	StageName    string     `json:"stage_name"`
+	ActiveItemID *string    `json:"active_item_id"`
+	CreatedBy    string     `json:"created_by"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+	DeletedAt    *time.Time `json:"-"`
+}
+
+// ManagementStore defines the interface for prompt management persistence.
+type ManagementStore interface {
+	Insert(ctx context.Context, pm *PromptManagement) error
+	Update(ctx context.Context, pm *PromptManagement) error
+	GetByID(ctx context.Context, id string) (*PromptManagement, error)
+	List(ctx context.Context, filters ListFilters) ([]*PromptManagement, int, error)
+	Delete(ctx context.Context, id string) error
+}
+
+// ListFilters represents the filtering parameters for listing prompt groups.
+type ListFilters struct {
+	Client  string
+	UseCase string
+	Page    int
+	PerPage int
+}

--- a/internal/domain/prompt.go
+++ b/internal/domain/prompt.go
@@ -31,8 +31,8 @@ type ManagementStore interface {
 
 // ListFilters represents the filtering parameters for listing prompt groups.
 type ListFilters struct {
-	Client  string
-	UseCase string
-	Page    int
-	PerPage int
+	Client  string `json:"client"`
+	UseCase string `json:"use_case"`
+	Page    int    `json:"page"`
+	PerPage int    `json:"per_page"`
 }

--- a/internal/handler/management_handler.go
+++ b/internal/handler/management_handler.go
@@ -1,0 +1,160 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"prompt-management/internal/domain"
+	"prompt-management/internal/middleware"
+	"prompt-management/internal/service"
+	"prompt-management/pkg/response"
+	"prompt-management/pkg/validator"
+)
+
+// ManagementHandler handles HTTP requests for prompt management.
+type ManagementHandler struct {
+	service *service.ManagementService
+}
+
+// NewManagementHandler creates a new ManagementHandler.
+func NewManagementHandler(s *service.ManagementService) *ManagementHandler {
+	return &ManagementHandler{service: s}
+}
+
+// Create handles the POST /prompts/create action.
+func (h *ManagementHandler) Create(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.Error(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	userID, ok := r.Context().Value(middleware.UserIDContextKey).(string)
+	if !ok {
+		response.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	var input service.CreateRequest
+	if err := validator.DecodeAndValidate(r, &input); err != nil {
+		response.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	pm, err := h.service.Create(r.Context(), input, userID)
+	if err != nil {
+		if errors.Is(err, domain.ErrValidation) {
+			response.Error(w, http.StatusBadRequest, "invalid input")
+			return
+		}
+		response.Error(w, http.StatusInternalServerError, "failed to create prompt group")
+		return
+	}
+
+	response.JSON(w, http.StatusCreated, pm)
+}
+
+// Update handles the POST /prompts/update action.
+func (h *ManagementHandler) Update(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.Error(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var input service.UpdateRequest
+	if err := validator.DecodeAndValidate(r, &input); err != nil {
+		response.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	pm, err := h.service.Update(r.Context(), input)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			response.Error(w, http.StatusNotFound, "prompt group not found")
+			return
+		}
+		response.Error(w, http.StatusInternalServerError, "failed to update prompt group")
+		return
+	}
+
+	response.JSON(w, http.StatusOK, pm)
+}
+
+// Get handles the POST /prompts/get action.
+func (h *ManagementHandler) Get(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.Error(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var input struct {
+		ID string `json:"id"`
+	}
+	if err := validator.DecodeAndValidate(r, &input); err != nil {
+		response.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	pm, err := h.service.GetByID(r.Context(), input.ID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			response.Error(w, http.StatusNotFound, "prompt group not found")
+			return
+		}
+		response.Error(w, http.StatusInternalServerError, "failed to get prompt group")
+		return
+	}
+
+	response.JSON(w, http.StatusOK, pm)
+}
+
+// List handles the POST /prompts/list action.
+func (h *ManagementHandler) List(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.Error(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var input domain.ListFilters
+	if err := validator.DecodeAndValidate(r, &input); err != nil {
+		response.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	groups, total, err := h.service.List(r.Context(), input)
+	if err != nil {
+		response.Error(w, http.StatusInternalServerError, "failed to list prompt groups")
+		return
+	}
+
+	response.JSON(w, http.StatusOK, map[string]interface{}{
+		"groups": groups,
+		"total":  total,
+	})
+}
+
+// Delete handles the POST /prompts/delete action.
+func (h *ManagementHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.Error(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var input struct {
+		ID string `json:"id"`
+	}
+	if err := validator.DecodeAndValidate(r, &input); err != nil {
+		response.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := h.service.Delete(r.Context(), input.ID); err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			response.Error(w, http.StatusNotFound, "prompt group not found")
+			return
+		}
+		response.Error(w, http.StatusInternalServerError, "failed to delete prompt group")
+		return
+	}
+
+	response.JSON(w, http.StatusOK, map[string]string{"message": "prompt group deleted successfully"})
+}

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -2,12 +2,16 @@ package handler
 
 import (
 	"net/http"
+	"prompt-management/internal/config"
+	"prompt-management/internal/middleware"
 )
 
 // RouterConfig holds the handlers for the router.
 type RouterConfig struct {
-	Health *HealthHandler
-	Auth   *AuthHandler
+	Config     *config.Config
+	Health     *HealthHandler
+	Auth       *AuthHandler
+	Management *ManagementHandler
 }
 
 // NewRouter registers all routes and returns the central mux.
@@ -21,6 +25,17 @@ func NewRouter(cfg RouterConfig) *http.ServeMux {
 	// Auth Endpoints (POST only as per interlock rules)
 	mux.HandleFunc("/auth/register", cfg.Auth.Register)
 	mux.HandleFunc("/auth/login", cfg.Auth.Login)
+
+	// Prompt Management (Authenticated)
+	authMW := func(next http.HandlerFunc) http.Handler {
+		return middleware.Authenticate(cfg.Config, next)
+	}
+
+	mux.Handle("/prompts/create", authMW(cfg.Management.Create))
+	mux.Handle("/prompts/update", authMW(cfg.Management.Update))
+	mux.Handle("/prompts/get", authMW(cfg.Management.Get))
+	mux.Handle("/prompts/list", authMW(cfg.Management.List))
+	mux.Handle("/prompts/delete", authMW(cfg.Management.Delete))
 
 	return mux
 }

--- a/internal/repository/postgres/management_repo.go
+++ b/internal/repository/postgres/management_repo.go
@@ -1,0 +1,189 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"prompt-management/internal/domain"
+)
+
+type managementRepo struct {
+	db *pgxpool.Pool
+}
+
+// NewManagementRepository creates a new PostgreSQL prompt management repository.
+func NewManagementRepository(db *pgxpool.Pool) domain.ManagementStore {
+	return &managementRepo{db: db}
+}
+
+func (r *managementRepo) Insert(ctx context.Context, pm *domain.PromptManagement) error {
+	query := `
+		INSERT INTO prompt_management (client, use_case, document_type, category, stage_name, created_by)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, created_at, updated_at`
+
+	err := r.db.QueryRow(ctx, query,
+		pm.Client,
+		pm.UseCase,
+		pm.DocumentType,
+		pm.Category,
+		pm.StageName,
+		pm.CreatedBy,
+	).Scan(&pm.ID, &pm.CreatedAt, &pm.UpdatedAt)
+
+	if err != nil {
+		return fmt.Errorf("could not insert prompt group: %w", err)
+	}
+
+	return nil
+}
+
+func (r *managementRepo) Update(ctx context.Context, pm *domain.PromptManagement) error {
+	query := `
+		UPDATE prompt_management
+		SET client = $1, use_case = $2, document_type = $3, category = $4, stage_name = $5, updated_at = NOW()
+		WHERE id = $6 AND deleted_at IS NULL
+		RETURNING updated_at`
+
+	err := r.db.QueryRow(ctx, query,
+		pm.Client,
+		pm.UseCase,
+		pm.DocumentType,
+		pm.Category,
+		pm.StageName,
+		pm.ID,
+	).Scan(&pm.UpdatedAt)
+
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.ErrNotFound
+		}
+		return fmt.Errorf("could not update prompt group: %w", err)
+	}
+
+	return nil
+}
+
+func (r *managementRepo) GetByID(ctx context.Context, id string) (*domain.PromptManagement, error) {
+	query := `
+		SELECT id, client, use_case, document_type, category, stage_name, active_item_id, created_by, created_at, updated_at
+		FROM prompt_management
+		WHERE id = $1 AND deleted_at IS NULL`
+
+	var pm domain.PromptManagement
+	err := r.db.QueryRow(ctx, query, id).Scan(
+		&pm.ID,
+		&pm.Client,
+		&pm.UseCase,
+		&pm.DocumentType,
+		&pm.Category,
+		&pm.StageName,
+		&pm.ActiveItemID,
+		&pm.CreatedBy,
+		&pm.CreatedAt,
+		&pm.UpdatedAt,
+	)
+
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("could not get prompt group: %w", err)
+	}
+
+	return &pm, nil
+}
+
+func (r *managementRepo) List(ctx context.Context, f domain.ListFilters) ([]*domain.PromptManagement, int, error) {
+	baseQuery := `
+		FROM prompt_management
+		WHERE deleted_at IS NULL`
+	
+	args := []interface{}{}
+	argIdx := 1
+
+	if f.Client != "" {
+		baseQuery += fmt.Sprintf(" AND client = $%d", argIdx)
+		args = append(args, f.Client)
+		argIdx++
+	}
+
+	if f.UseCase != "" {
+		baseQuery += fmt.Sprintf(" AND use_case = $%d", argIdx)
+		args = append(args, f.UseCase)
+		argIdx++
+	}
+
+	// Count total
+	var total int
+	countQuery := "SELECT COUNT(*) " + baseQuery
+	err := r.db.QueryRow(ctx, countQuery, args...).Scan(&total)
+	if err != nil {
+		return nil, 0, fmt.Errorf("could not count prompt groups: %w", err)
+	}
+
+	// Fetch data
+	if f.PerPage <= 0 {
+		f.PerPage = 20
+	}
+	if f.Page <= 0 {
+		f.Page = 1
+	}
+
+	dataQuery := `
+		SELECT id, client, use_case, document_type, category, stage_name, active_item_id, created_by, created_at, updated_at ` +
+		baseQuery +
+		fmt.Sprintf(" ORDER BY created_at DESC LIMIT $%d OFFSET $%d", argIdx, argIdx+1)
+	
+	args = append(args, f.PerPage, (f.Page-1)*f.PerPage)
+
+	rows, err := r.db.Query(ctx, dataQuery, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("could not query prompt groups: %w", err)
+	}
+	defer rows.Close()
+
+	var groups []*domain.PromptManagement
+	for rows.Next() {
+		var pm domain.PromptManagement
+		err := rows.Scan(
+			&pm.ID,
+			&pm.Client,
+			&pm.UseCase,
+			&pm.DocumentType,
+			&pm.Category,
+			&pm.StageName,
+			&pm.ActiveItemID,
+			&pm.CreatedBy,
+			&pm.CreatedAt,
+			&pm.UpdatedAt,
+		)
+		if err != nil {
+			return nil, 0, fmt.Errorf("could not scan prompt group: %w", err)
+		}
+		groups = append(groups, &pm)
+	}
+
+	return groups, total, nil
+}
+
+func (r *managementRepo) Delete(ctx context.Context, id string) error {
+	query := `
+		UPDATE prompt_management
+		SET deleted_at = NOW()
+		WHERE id = $1 AND deleted_at IS NULL`
+
+	res, err := r.db.Exec(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("could not delete prompt group: %w", err)
+	}
+
+	if res.RowsAffected() == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
+}

--- a/internal/service/management_service.go
+++ b/internal/service/management_service.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+
+	"prompt-management/internal/domain"
+)
+
+// ManagementService handles business logic for prompt management.
+type ManagementService struct {
+	repo domain.ManagementStore
+}
+
+// NewManagementService creates a new ManagementService.
+func NewManagementService(repo domain.ManagementStore) *ManagementService {
+	return &ManagementService{repo: repo}
+}
+
+// CreateRequest defines the payload for creating a prompt group.
+type CreateRequest struct {
+	Client       string `json:"client"`
+	UseCase      string `json:"use_case"`
+	DocumentType string `json:"document_type"`
+	Category     string `json:"category"`
+	StageName    string `json:"stage_name"`
+}
+
+// UpdateRequest defines the payload for updating a prompt group.
+type UpdateRequest struct {
+	ID           string `json:"id"`
+	Client       string `json:"client"`
+	UseCase      string `json:"use_case"`
+	DocumentType string `json:"document_type"`
+	Category     string `json:"category"`
+	StageName    string `json:"stage_name"`
+}
+
+func (s *ManagementService) Create(ctx context.Context, req CreateRequest, userID string) (*domain.PromptManagement, error) {
+	// Basic validation
+	if req.Client == "" || req.UseCase == "" || req.DocumentType == "" || req.Category == "" || req.StageName == "" {
+		return nil, domain.ErrValidation
+	}
+
+	pm := &domain.PromptManagement{
+		Client:       req.Client,
+		UseCase:      req.UseCase,
+		DocumentType: req.DocumentType,
+		Category:     req.Category,
+		StageName:    req.StageName,
+		CreatedBy:    userID,
+	}
+
+	if err := s.repo.Insert(ctx, pm); err != nil {
+		return nil, err
+	}
+
+	return pm, nil
+}
+
+func (s *ManagementService) Update(ctx context.Context, req UpdateRequest) (*domain.PromptManagement, error) {
+	if req.ID == "" {
+		return nil, domain.ErrValidation
+	}
+
+	pm, err := s.repo.GetByID(ctx, req.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update fields
+	if req.Client != "" {
+		pm.Client = req.Client
+	}
+	if req.UseCase != "" {
+		pm.UseCase = req.UseCase
+	}
+	if req.DocumentType != "" {
+		pm.DocumentType = req.DocumentType
+	}
+	if req.Category != "" {
+		pm.Category = req.Category
+	}
+	if req.StageName != "" {
+		pm.StageName = req.StageName
+	}
+
+	if err := s.repo.Update(ctx, pm); err != nil {
+		return nil, err
+	}
+
+	return pm, nil
+}
+
+func (s *ManagementService) GetByID(ctx context.Context, id string) (*domain.PromptManagement, error) {
+	return s.repo.GetByID(ctx, id)
+}
+
+func (s *ManagementService) List(ctx context.Context, filters domain.ListFilters) ([]*domain.PromptManagement, int, error) {
+	return s.repo.List(ctx, filters)
+}
+
+func (s *ManagementService) Delete(ctx context.Context, id string) error {
+	return s.repo.Delete(ctx, id)
+}

--- a/migrations/000002_create_prompt_management_table.down.sql
+++ b/migrations/000002_create_prompt_management_table.down.sql
@@ -1,0 +1,2 @@
+-- 000002_create_prompt_management_table.down.sql
+DROP TABLE IF EXISTS prompt_management;

--- a/migrations/000002_create_prompt_management_table.up.sql
+++ b/migrations/000002_create_prompt_management_table.up.sql
@@ -1,0 +1,20 @@
+-- 000002_create_prompt_management_table.up.sql
+CREATE TABLE IF NOT EXISTS prompt_management (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    client TEXT NOT NULL,
+    use_case TEXT NOT NULL,
+    document_type TEXT NOT NULL,
+    category TEXT NOT NULL,
+    stage_name TEXT NOT NULL,
+    active_item_id UUID, -- Will be set/updated by Item Service
+    created_by UUID NOT NULL REFERENCES users(id),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP WITH TIME ZONE,
+
+    -- Enforce uniqueness on the business key to prevent duplicates
+    UNIQUE(client, use_case, document_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_prompt_management_client ON prompt_management (client) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_prompt_management_use_case ON prompt_management (use_case) WHERE deleted_at IS NULL;


### PR DESCRIPTION
Closes #15. Implements the Management Service for handling prompt metadata group CRUD operations. Includes database migrations, domain models, repository, service, and authenticated handlers.