### PR TITLE
feat: implement CORS middleware for issue #37

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -64,8 +64,9 @@ func main() {
 	})
 
 	// 6. Apply Global Middleware
-	// Order: Recovery -> Logger -> Mux
+	// Order: Recovery -> Logger -> CORS -> Mux
 	var handler http.Handler = mux
+	handler = middleware.EnableCORS(handler)
 	handler = middleware.LogRequest(logger)(handler)
 	handler = middleware.RecoverPanic(logger)(handler)
 

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -1,0 +1,24 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+// EnableCORS adds basic CORS headers to the response and handles preflight OPTIONS requests.
+func EnableCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Set CORS headers
+		w.Header().Set("Access-Control-Allow-Origin", "http://localhost:4200") // Angular app origin
+		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+
+		// Handle preflight requests
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/middleware/cors_test.go
+++ b/internal/middleware/cors_test.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEnableCORS(t *testing.T) {
+	// 1. Setup a simple test handler
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// 2. Wrap with EnableCORS
+	corsHandler := EnableCORS(nextHandler)
+
+	// 3. Test a standard POST request
+	t.Run("Standard POST request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		w := httptest.NewRecorder()
+
+		corsHandler.ServeHTTP(w, req)
+
+		expectedOrigin := "http://localhost:4200"
+		if origin := w.Header().Get("Access-Control-Allow-Origin"); origin != expectedOrigin {
+			t.Errorf("expected Access-Control-Allow-Origin %s, got %s", expectedOrigin, origin)
+		}
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected status code %d, got %d", http.StatusOK, w.Code)
+		}
+	})
+
+	// 4. Test an OPTIONS preflight request
+	t.Run("OPTIONS preflight request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/", nil)
+		w := httptest.NewRecorder()
+
+		corsHandler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNoContent {
+			t.Errorf("expected status code %d for preflight, got %d", http.StatusNoContent, w.Code)
+		}
+
+		expectedMethods := "POST, GET, OPTIONS, PUT, DELETE"
+		if methods := w.Header().Get("Access-Control-Allow-Methods"); methods != expectedMethods {
+			t.Errorf("expected Access-Control-Allow-Methods %s, got %s", expectedMethods, methods)
+		}
+	})
+}


### PR DESCRIPTION
This PR implements CORS middleware to allow the Angular frontend (running on `http://localhost:4200`) to communicate with the backend API.

### Changes:
- Added `internal/middleware/cors.go` with `EnableCORS` middleware.
- Integrated `EnableCORS` into the global middleware chain in `cmd/api/main.go`.
- Added unit tests in `internal/middleware/cors_test.go`.

### Verification:
- Tests passed locally: `go test -v ./internal/middleware/cors_test.go ./internal/middleware/cors.go`
- Manual verification: Preflight `OPTIONS` requests are handled, and CORS headers are injected.

Fixes #37