### PR TITLE
feat: change login response structure to Value/Error for issue #39

### DIFF
--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -57,16 +58,21 @@ type loginRequest struct {
 	Password   string `json:"password"`
 }
 
+type loginResponse struct {
+	Value string `json:"Value"`
+	Error string `json:"Error"`
+}
+
 func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		response.Error(w, http.StatusMethodNotAllowed, "method not allowed")
+		h.sendLoginResponse(w, http.StatusMethodNotAllowed, "", "method not allowed")
 		return
 	}
 
 	var input loginRequest
 	err := validator.DecodeAndValidate(r, &input)
 	if err != nil {
-		response.Error(w, http.StatusBadRequest, err.Error())
+		h.sendLoginResponse(w, http.StatusBadRequest, "", err.Error())
 		return
 	}
 
@@ -74,14 +80,23 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	token, err := h.service.Login(r.Context(), input.Identifier, input.Password)
 	if err != nil {
 		if errors.Is(err, domain.ErrUnauthorized) {
-			response.Error(w, http.StatusUnauthorized, "invalid credentials")
+			h.sendLoginResponse(w, http.StatusUnauthorized, "", "invalid credentials")
 			return
 		}
-		response.Error(w, http.StatusInternalServerError, "login failed")
+		h.sendLoginResponse(w, http.StatusInternalServerError, "", "login failed")
 		return
 	}
 
-	response.JSON(w, http.StatusOK, map[string]string{"token": token})
+	h.sendLoginResponse(w, http.StatusOK, token, "")
+}
+
+func (h *AuthHandler) sendLoginResponse(w http.ResponseWriter, status int, value, err string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(loginResponse{
+		Value: value,
+		Error: err,
+	})
 }
 
 // Refresh handles stateless token extensions.

--- a/internal/handler/auth_handler_structure_test.go
+++ b/internal/handler/auth_handler_structure_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoginResponseStructure(t *testing.T) {
+	h := &AuthHandler{} // Mock service is not needed just for checking structure if we mock the handler call or just test the helper
+
+	t.Run("sendLoginResponse Success", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h.sendLoginResponse(w, http.StatusOK, "test-token", "")
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", w.Code)
+		}
+
+		var resp loginResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+
+		if resp.Value != "test-token" {
+			t.Errorf("expected Value 'test-token', got '%s'", resp.Value)
+		}
+		if resp.Error != "" {
+			t.Errorf("expected Error empty, got '%s'", resp.Error)
+		}
+	})
+
+	t.Run("sendLoginResponse Error", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h.sendLoginResponse(w, http.StatusUnauthorized, "", "invalid credentials")
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("expected status 401, got %d", w.Code)
+		}
+
+		var resp loginResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+
+		if resp.Value != "" {
+			t.Errorf("expected Value empty, got '%s'", resp.Value)
+		}
+		if resp.Error != "invalid credentials" {
+			t.Errorf("expected Error 'invalid credentials', got '%s'", resp.Error)
+		}
+	})
+}


### PR DESCRIPTION
This PR changes the response structure of the `/auth/login` endpoint to return `{ "Value": "token", "Error": "" }` to match the frontend requirements.

### Changes:
- **Backend:** Updated `AuthHandler.Login` to use a new `loginResponse` struct.
- **Backend:** Added `auth_handler_structure_test.go` to verify the new structure.
- **Frontend (Manual Step):** The user has been instructed to update (and I have already provided the code for) `authUser.ts` and `login.service.ts` in the Angular project.

Fixes #39